### PR TITLE
XIVY-10509 Fix remove unknown mappings

### DIFF
--- a/packages/editor/src/components/widgets/table/MappingTree.test.tsx
+++ b/packages/editor/src/components/widgets/table/MappingTree.test.tsx
@@ -90,7 +90,6 @@ describe('MappingTree', () => {
   test('tree will render unknown values', () => {
     renderTree([{ key: 'bla', value: 'unknown value' }]);
     assertTableRows([EXP_ATTRIBUTES, EXP_PARAMS, NODE_BOOLEAN, NODE_NUMBER, COL_USER, /⛔ bla unknown value/]);
-    expect(screen.getByDisplayValue('unknown value')).toBeDisabled();
   });
 
   test('tree can expand / collapse', async () => {

--- a/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
@@ -42,7 +42,7 @@ export function CodeEditorCell<TData>(props: { cell: CellContext<TData, unknown>
           value={value as string}
           onChange={e => setValue(e.target.value)}
           onClick={() => setIsActive(true)}
-          disabled={readonly || props.type.length === 0}
+          disabled={readonly}
         />
       )}
     </>


### PR DESCRIPTION
Thougt to disable the input if the type is not known (or the mapping is wrong) is cool, but it also prevent the user from remove those unknown mappings :D