### PR TITLE
Improve build infrastructure

### DIFF
--- a/.ivy/raise-build-plugin-version.sh
+++ b/.ivy/raise-build-plugin-version.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mvn --batch-mode versions:set-property versions:commit -f integrations/standalone/tests/engine/project/pom.xml -Dproperty=project.build.plugin.version -DnewVersion=${2} -DallowSnapshots=true
+mvn --batch-mode versions:set-property versions:commit -f integrations/standalone/tests/screenshots/project/pom.xml -Dproperty=project.build.plugin.version -DnewVersion=${2} -DallowSnapshots=true

--- a/.ivy/raise-version.sh
+++ b/.ivy/raise-version.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mvn --batch-mode -f integrations/standalone/pom.xml versions:set versions:commit -DnewVersion=${1}
+mvn --batch-mode -f integrations/standalone/tests/screenshots/pom.xmlversions:set versions:commit -DnewVersion=${1}
+mvn --batch-mode -f integrations/standalone/tests/engine/project/pom.xml versions:set versions:commit -DnewVersion=${1}
+mvn --batch-mode -f integrations/standalone/tests/screenshots/project/pom.xml versions:set versions:commit -DnewVersion=${1}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
         script {
           catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
             docker.build('node').inside {
+              sh 'build/use-mirror-npm.sh'
               sh 'yarn ci'
             }
           }
@@ -29,7 +30,7 @@ pipeline {
     stage('Mock Tests') {
       steps {
         script {
-          docker.image('mcr.microsoft.com/playwright:v1.30.0').inside {
+          docker.image('mcr.microsoft.com/playwright:v1.30.0-jammy').inside {
             sh 'yarn standalone webtest:mock'
           }
           archiveArtifacts artifacts: '**/standalone/test-results/**', allowEmptyArchive: true

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,22 +1,7 @@
-FROM mcr.microsoft.com/playwright:v1.30.0
+FROM mcr.microsoft.com/playwright:v1.30.0-jammy
 
 RUN apt-get update &&\
   apt-get install software-properties-common -y &&\
   apt-add-repository universe -y &&\
   apt-get update &&\
-  apt-get install openjdk-17-jdk -y
-
-ARG MAVEN_VERSION=3.8.7
-ARG USER_HOME_DIR="/root"
-ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
-
-ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+  apt-get install openjdk-17-jdk maven -y

--- a/build/engine/Jenkinsfile
+++ b/build/engine/Jenkinsfile
@@ -18,6 +18,7 @@ pipeline {
       steps {
         script {
           docker.build('node-webtest', '-f build/Dockerfile .').inside {
+            sh 'build/use-mirror-npm.sh'
             sh 'yarn'
             dir ('integrations/standalone/tests/engine/project') {
               maven cmd: "-ntp verify -Dengine.page.url=${params.engineSource}"

--- a/build/screenshots/Jenkinsfile
+++ b/build/screenshots/Jenkinsfile
@@ -18,6 +18,7 @@ pipeline {
       steps {
         script {
           docker.build('node-webtest', '-f build/Dockerfile .').inside {
+            sh 'build/use-mirror-npm.sh'
             sh 'yarn'
             dir ('integrations/standalone/tests/screenshots/project') {
               maven cmd: "-ntp verify -Dengine.page.url=${params.engineSource}"

--- a/build/use-mirror-npm.sh
+++ b/build/use-mirror-npm.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sed -i -e "s#https://registry.yarnpkg.com/#https://npm-registry.ivyteam.io/repository/npm/#g" yarn.lock


### PR DESCRIPTION
- Use playwright jammy image (Ubuntu 22.04)
- Install maven via apt
- Use mirror npm for CI
- Add raise version scripts