### PR TITLE
Enable all engine integration tests

### DIFF
--- a/integrations/standalone/tests/engine/tabs/output-tab.ts
+++ b/integrations/standalone/tests/engine/tabs/output-tab.ts
@@ -16,7 +16,7 @@ export class OutputTabTester implements TabTest {
     }
   }
   async assertFill(page: Page) {
-    //FIXME output map is not always send to view: await TableUtil.assertRow(page, 1, ['"bla"']);
+    await TableUtil.assertRow(page, 1, ['"bla"']);
     if (this.hasCode) {
       await CodeEditorUtil.assertValue(page, 'ivy.log.info("hi");');
     }

--- a/integrations/standalone/tests/engine/tabs/task-tab.ts
+++ b/integrations/standalone/tests/engine/tabs/task-tab.ts
@@ -85,6 +85,6 @@ export const TaskTabTest: TabTest = {
     await CollapseUtil.assertClosed(page, 'Options');
     await CollapseUtil.assertClosed(page, 'Expiry');
     await CollapseUtil.assertClosed(page, 'Custom Fields');
-    //FIXME: await CollapseUtil.assertClosed(page, 'Code');
+    await CollapseUtil.assertClosed(page, 'Code');
   }
 };

--- a/integrations/standalone/tests/engine/tabs/task-tab.ts
+++ b/integrations/standalone/tests/engine/tabs/task-tab.ts
@@ -71,6 +71,7 @@ export const TaskTabTest: TabTest = {
 
     await TableUtil.removeRow(page, 0);
 
+    await CodeEditorUtil.focus(page);
     await CodeEditorUtil.clear(page);
   },
   assertClear: async (page: Page) => {


### PR DESCRIPTION
Hi @ivy-rew 
This PR enables the unstable/wrong assertions
[Client build](https://jenkins.ivyteam.io/job/inscription-view/job/all-engine-tests/)
[Engine Integration Build](https://jenkins.ivyteam.io/job/inscription-view-integration/job/all-engine-tests/)
[Screenshots](https://jenkins.ivyteam.io/job/inscription-view-screenshot/job/all-engine-tests/)