### PR TITLE
Fix combocell

### DIFF
--- a/packages/editor/src/components/parts/common/customfield/CustomFieldTable.test.tsx
+++ b/packages/editor/src/components/parts/common/customfield/CustomFieldTable.test.tsx
@@ -46,6 +46,35 @@ describe('CustomFieldTable', () => {
     await TableUtil.assertRemoveRow(view, 1);
   });
 
+  test('table can add rows by keyboard', async () => {
+    const view = renderTable();
+    await TableUtil.assertAddRowWithKeyboard(view, 'number');
+
+    expect(view.data()).toEqual([
+      { name: 'field1', type: 'STRING', value: 'this is a string' },
+      { name: 'number', type: 'NUMBER', value: '1' },
+      { name: '', type: 'STRING', value: '' }
+    ]);
+  });
+
+  test('table can edit cells', async () => {
+    const view = renderTable();
+    const field1 = screen.getByDisplayValue(/field1/);
+    await userEvent.clear(field1);
+    await userEvent.type(field1, 'Hello[Tab]');
+    view.rerender();
+
+    const type = screen.getAllByRole('combobox')[1];
+    await userEvent.click(type);
+    await userEvent.click(type);
+    await userEvent.keyboard('[ArrowDown][Enter]');
+
+    expect(view.data()).toEqual([
+      { name: 'Hello', type: 'STRING', value: 'this is a string' },
+      { name: 'number', type: 'NUMBER', value: '1' }
+    ]);
+  });
+
   test('table support readonly mode', async () => {
     render(<CustomFieldTable data={customFields} onChange={() => {}} type='CASE' />, {
       wrapperProps: { editor: { readonly: true } }

--- a/packages/editor/src/components/parts/common/customfield/StartCustomFieldTable.test.tsx
+++ b/packages/editor/src/components/parts/common/customfield/StartCustomFieldTable.test.tsx
@@ -46,6 +46,31 @@ describe('StartCustomFieldTable', () => {
     await TableUtil.assertRemoveRow(view, 1);
   });
 
+  test('table can add/remove rows by keyboard', async () => {
+    const view = renderTable();
+    await userEvent.click(screen.getAllByRole('row')[2]);
+    await TableUtil.assertAddRowWithKeyboard(view, 'number');
+    expect(view.data()).toEqual([
+      { name: 'field1', value: 'this is a string' },
+      { name: 'number', value: '1' },
+      { name: '', value: '' }
+    ]);
+  });
+
+  test('table can edit cells', async () => {
+    const view = renderTable();
+    await userEvent.click(screen.getAllByRole('row')[1]);
+    const field1 = screen.getAllByRole('combobox')[0];
+    await userEvent.dblClick(field1);
+    await userEvent.keyboard('Hello');
+    await userEvent.tab();
+
+    expect(view.data()).toEqual([
+      { name: 'Hello', value: 'this is a string' },
+      { name: 'number', value: '1' }
+    ]);
+  });
+
   test('table support readonly mode', async () => {
     render(<StartCustomFieldTable data={customFields} onChange={() => {}} />, {
       wrapperProps: { editor: { readonly: true } }

--- a/packages/editor/src/components/parts/common/parameter/ParameterTable.test.tsx
+++ b/packages/editor/src/components/parts/common/parameter/ParameterTable.test.tsx
@@ -60,7 +60,7 @@ describe('ParameterTable', () => {
     expect(view.data()).toEqual([
       { name: 'field1', type: 'String', desc: 'this is a string' },
       { name: 'number', type: 'Number', desc: '1' },
-      { name: 'change_this_name', type: 'String', desc: '' }
+      { name: '', type: 'String', desc: '' }
     ]);
   });
 

--- a/packages/editor/src/components/parts/common/parameter/ParameterTable.tsx
+++ b/packages/editor/src/components/parts/common/parameter/ParameterTable.tsx
@@ -14,7 +14,7 @@ type ParameterTableProps = {
   hideDesc?: boolean;
 };
 
-const EMPTY_SCRIPT_VARIABLE: ScriptVariable = { name: 'change_this_name', type: 'String', desc: '' } as const;
+const EMPTY_SCRIPT_VARIABLE: ScriptVariable = { name: '', type: 'String', desc: '' } as const;
 
 const ParameterTable = ({ data, onChange, hideDesc, label }: ParameterTableProps) => {
   const columns = useMemo(() => {

--- a/packages/editor/src/components/widgets/combobox/Combobox.tsx
+++ b/packages/editor/src/components/widgets/combobox/Combobox.tsx
@@ -25,6 +25,7 @@ export type ComboboxProps<T extends ComboboxItem> = Omit<ComponentProps<'input'>
   onChange: (change: string) => void;
   macro?: boolean;
   browserTypes?: BrowserType[];
+  updateOnInputChange?: boolean;
 };
 
 const Combobox = <T extends ComboboxItem>({
@@ -35,6 +36,7 @@ const Combobox = <T extends ComboboxItem>({
   onChange,
   macro,
   browserTypes,
+  updateOnInputChange,
   ...inputProps
 }: ComboboxProps<T>) => {
   const filter = itemFilter
@@ -70,6 +72,9 @@ const Combobox = <T extends ComboboxItem>({
       onInputValueChange(change) {
         if (change.type !== useCombobox.stateChangeTypes.FunctionSelectItem) {
           setFilteredItems(items.filter(item => filter(item, change.inputValue)));
+          if (updateOnInputChange) {
+            onChange(change.inputValue ?? '');
+          }
         }
       },
       items: filteredItems,
@@ -80,9 +85,11 @@ const Combobox = <T extends ComboboxItem>({
     });
 
   useEffect(() => {
-    selectItem({ value });
-    setFilteredItems(items);
-  }, [items, selectItem, value]);
+    if (!updateOnInputChange || updateOnInputChange == undefined) {
+      selectItem({ value });
+      setFilteredItems(items);
+    }
+  }, [updateOnInputChange, items, selectItem, value]);
 
   const readonly = useReadonly();
   const { setEditor, modifyEditor } = useMonacoEditor({ modifyAction: value => `<%=${value}%>` });

--- a/packages/editor/src/components/widgets/table/cell/ComboCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/ComboCell.tsx
@@ -16,7 +16,7 @@ export function ComboCell<TData>({ cell, items }: { cell: CellContext<TData, unk
   const setValue = (value: string) => {
     cell.table.options.meta?.updateData(cell.row.id, cell.column.id, value);
   };
-  const { isFocusWithin, focusWithinProps, focusValue } = useOnFocus(value as string, change => setValue(change));
+  const { isFocusWithin, focusWithinProps, focusValue } = useOnFocus(value as string, change => setValue(change as string));
 
   useEffect(() => {
     if (isFocusWithin && !cell.row.getIsSelected()) {
@@ -26,7 +26,7 @@ export function ComboCell<TData>({ cell, items }: { cell: CellContext<TData, unk
 
   return (
     <div {...focusWithinProps}>
-      <Combobox items={items} value={focusValue.value} onChange={setValue} />
+      <Combobox items={items} value={focusValue.value} onChange={focusValue.onChange} updateOnInputChange={true} />
     </div>
   );
 }


### PR DESCRIPTION
I've adjusted the combobox for use with the combocell, as the new table behavior prevents direct adoption. To avoid creating a new combobox in the combocell (since most of it can be reused), I added the "asCell" flag. Hope that's alright. 

Also, I've re-added the tests for the customfieldstable and removed the "change_this_name" as it is no longer necessary if the changes from the core are merged.