### PR TITLE
XIVY-15332 Use normal table if rows are not expanded in function browser

### DIFF
--- a/packages/editor/src/components/browser/BrowserTableRow.tsx
+++ b/packages/editor/src/components/browser/BrowserTableRow.tsx
@@ -1,0 +1,12 @@
+import { SelectRow, TableCell } from '@axonivy/ui-components';
+import { flexRender, type Row } from '@tanstack/react-table';
+
+const BrowserTableRow = <T,>({ row, onDoubleClick }: { row: Row<T>; onDoubleClick: () => void }) => (
+  <SelectRow key={row.id} row={row} onDoubleClick={onDoubleClick}>
+    {row.getVisibleCells().map(cell => (
+      <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+    ))}
+  </SelectRow>
+);
+
+export default BrowserTableRow;

--- a/packages/editor/src/components/browser/attribute/AttributeBrowser.tsx
+++ b/packages/editor/src/components/browser/attribute/AttributeBrowser.tsx
@@ -9,7 +9,8 @@ import { useEditorContext, useMeta } from '../../../context';
 import { calcFullPathId } from '../../parts/common/mapping-tree/useMappingTree';
 import { IvyIcons } from '@axonivy/ui-icons';
 import type { BrowserValue } from '../Browser';
-import { ExpandableHeader, SelectRow, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@axonivy/ui-components';
+import { ExpandableHeader, TableBody, TableHead, TableHeader, TableRow } from '@axonivy/ui-components';
+import BrowserTableRow from '../BrowserTableRow';
 
 export const ATTRIBUTE_BROWSER_ID = 'attr' as const;
 
@@ -132,11 +133,7 @@ const AttributeBrowser = ({
         </TableHeader>
         <TableBody>
           {table.getRowModel().rows.map(row => (
-            <SelectRow key={row.id} row={row} onDoubleClick={onDoubleClick}>
-              {row.getVisibleCells().map(cell => (
-                <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
-              ))}
-            </SelectRow>
+            <BrowserTableRow key={row.id} row={row} onDoubleClick={onDoubleClick} />
           ))}
         </TableBody>
       </SearchTable>

--- a/packages/editor/src/components/browser/role/RoleBrowser.tsx
+++ b/packages/editor/src/components/browser/role/RoleBrowser.tsx
@@ -9,14 +9,14 @@ import {
   type RowSelectionState,
   getCoreRowModel,
   getFilteredRowModel,
-  flexRender,
   type ExpandedState,
   getExpandedRowModel
 } from '@tanstack/react-table';
 import { useRoles } from '../../parts/common/responsible/useRoles';
 import type { RoleMeta } from '@axonivy/inscription-protocol';
-import { Flex, SelectRow, TableBody, TableCell, TableRow } from '@axonivy/ui-components';
+import { Flex, TableBody, TableCell, TableRow } from '@axonivy/ui-components';
 import { AddRolePopover } from './AddRolePopover';
+import BrowserTableRow from '../BrowserTableRow';
 export const ROLE_BROWSER = 'role' as const;
 
 export type RoleOptions = {
@@ -123,13 +123,7 @@ const RoleBrowser = (props: {
       >
         <TableBody>
           {table.getRowModel().rows.length > 0 ? (
-            table.getRowModel().rows.map(row => (
-              <SelectRow key={row.id} row={row} onDoubleClick={props.onDoubleClick}>
-                {row.getVisibleCells().map(cell => (
-                  <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
-                ))}
-              </SelectRow>
-            ))
+            table.getRowModel().rows.map(row => <BrowserTableRow key={row.id} row={row} onDoubleClick={props.onDoubleClick} />)
           ) : (
             <TableRow>
               <TableCell>No Columns found</TableCell>

--- a/packages/editor/src/components/browser/tableCol/TableColBrowser.tsx
+++ b/packages/editor/src/components/browser/tableCol/TableColBrowser.tsx
@@ -4,17 +4,11 @@ import type { UseBrowserImplReturnValue } from '../useBrowser';
 import { IvyIcons } from '@axonivy/ui-icons';
 import type { BrowserValue } from '../Browser';
 import { useEditorContext, useMeta } from '../../../context';
-import {
-  useReactTable,
-  type ColumnDef,
-  type RowSelectionState,
-  getCoreRowModel,
-  getFilteredRowModel,
-  flexRender
-} from '@tanstack/react-table';
+import { useReactTable, type ColumnDef, type RowSelectionState, getCoreRowModel, getFilteredRowModel } from '@tanstack/react-table';
 import { useQueryData } from '../../parts/query/useQueryData';
 import type { DatabaseColumn } from '@axonivy/inscription-protocol';
-import { SelectRow, TableBody, TableCell, TableRow } from '@axonivy/ui-components';
+import { TableBody, TableCell, TableRow } from '@axonivy/ui-components';
+import BrowserTableRow from '../BrowserTableRow';
 export const TABLE_COL_BROWSER_ID = 'tablecol' as const;
 
 export const useTableColBrowser = (onDoubleClick: () => void): UseBrowserImplReturnValue => {
@@ -109,13 +103,7 @@ const TableColumnBrowser = (props: { value: string; onChange: (value: BrowserVal
       >
         <TableBody>
           {table.getRowModel().rows.length > 0 ? (
-            table.getRowModel().rows.map(row => (
-              <SelectRow key={row.id} row={row} onDoubleClick={props.onDoubleClick}>
-                {row.getVisibleCells().map(cell => (
-                  <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
-                ))}
-              </SelectRow>
-            ))
+            table.getRowModel().rows.map(row => <BrowserTableRow key={row.id} row={row} onDoubleClick={props.onDoubleClick} />)
           ) : (
             <TableRow>
               <TableCell>No Columns found</TableCell>

--- a/packages/editor/src/components/browser/type/TypeBrowser.tsx
+++ b/packages/editor/src/components/browser/type/TypeBrowser.tsx
@@ -2,13 +2,14 @@ import { useMemo, useState, useEffect } from 'react';
 import { Checkbox, ExpandableCell, SearchTable } from '../../widgets';
 import type { UseBrowserImplReturnValue } from '../useBrowser';
 import type { ColumnDef, ExpandedState, FilterFn, RowSelectionState } from '@tanstack/react-table';
-import { flexRender, getCoreRowModel, getExpandedRowModel, getFilteredRowModel, useReactTable } from '@tanstack/react-table';
+import { getCoreRowModel, getExpandedRowModel, getFilteredRowModel, useReactTable } from '@tanstack/react-table';
 import { useEditorContext, useMeta } from '../../../context';
 import type { JavaType } from '@axonivy/inscription-protocol';
 import { IvyIcons } from '@axonivy/ui-icons';
 import type { BrowserValue } from '../Browser';
 import { getCursorValue } from './cursor-value';
-import { SelectRow, TableBody, TableCell } from '@axonivy/ui-components';
+import { TableBody, TableCell } from '@axonivy/ui-components';
+import BrowserTableRow from '../BrowserTableRow';
 export const TYPE_BROWSER_ID = 'type' as const;
 
 export type TypeBrowserObject = JavaType & { icon: IvyIcons };
@@ -244,13 +245,7 @@ const TypeBrowser = ({ value, onChange, onDoubleClick, initSearchFilter, locatio
           {tableDynamic.getRowModel().rows.length > 0 ? (
             <>
               {!isFetching &&
-                tableDynamic.getRowModel().rows.map(row => (
-                  <SelectRow key={row.id} row={row} onDoubleClick={onDoubleClick}>
-                    {row.getVisibleCells().map(cell => (
-                      <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
-                    ))}
-                  </SelectRow>
-                ))}
+                tableDynamic.getRowModel().rows.map(row => <BrowserTableRow key={row.id} row={row} onDoubleClick={onDoubleClick} />)}
             </>
           ) : (
             <tr>


### PR DESCRIPTION
Due to setExpanded, the initial state can only be set to true, otherwise the rows won't render (the exact reason is unclear). Initially, I use the regular table, and once any "ivy" children are expanded (either manually or via search), the virtual table is used.

Also, I refactored the sortedTree useEffect into a useMemo. I think this is better for re-rendering purposes, right?
![example_function](https://github.com/user-attachments/assets/62b82b04-58eb-49d8-9ad7-9c18ee498f40)
